### PR TITLE
refactor: improve virtualization role idempotency and network config

### DIFF
--- a/roles/virtualization/tasks/main.yml
+++ b/roles/virtualization/tasks/main.yml
@@ -56,9 +56,9 @@
       community.general.nmcli:
         conn_name: "bridge-slave-{{ virtualization_active_nic }}"
         ifname: "{{ virtualization_active_nic }}"
-        type: ethernet      # The underlying hardware type
-        slave_type: bridge  # The role it plays
-        master: br0         # The controller it belongs to
+        type: ethernet
+        slave_type: bridge
+        master: br0
         state: present
       async: 45
       poll: 5
@@ -67,47 +67,30 @@
       ansible.builtin.pause:
         seconds: 5
 
-    - name: Define bridged network XML
+    - name: Configure libvirt networks
       community.libvirt.virt_net:
-        name: bridged
-        state: present
-        xml: |
-          <network>
-            <name>bridged</name>
-            <forward mode="bridge"/>
-            <bridge name="br0"/>
-          </network>
-
-    - name: Ensure bridged network is active and autostarted
-      community.libvirt.virt_net:
-        name: bridged
+        name: "{{ item.name }}"
         state: active
         autostart: true
-
-    - name: Define isolated network XML
-      community.libvirt.virt_net:
-        name: isolated
-        state: present
-        xml: |
-          <network>
-            <name>isolated</name>
-            <bridge name="virbr666" stp="on" delay="0"/>
-            <ip address="10.66.6.1" netmask="255.255.255.0">
-              <dhcp>
-                <range start="10.66.6.66" end="10.66.6.254"/>
-              </dhcp>
-            </ip>
-          </network>
-
-    - name: Ensure isolated network is active and autostarted
-      community.libvirt.virt_net:
-        name: isolated
-        state: active
-        autostart: true
-
-    - name: Ensure all libvirt networks are active and set to autostart
-      ansible.builtin.shell: virsh net-autostart "{{ item }}"
-      changed_when: false
-      loop: "{{ virtualization_kvm_qemu.networks }}"
-
+        xml: "{{ item.xml | default(omit) }}"
+      loop:
+        - name: default
+        - name: bridged
+          xml: |
+            <network>
+              <name>bridged</name>
+              <forward mode="bridge"/>
+              <bridge name="br0"/>
+            </network>
+        - name: isolated
+          xml: |
+            <network>
+              <name>isolated</name>
+              <bridge name="virbr666" stp="on" delay="0"/>
+              <ip address="10.66.6.1" netmask="255.255.255.0">
+                <dhcp>
+                  <range start="10.66.6.66" end="10.66.6.254"/>
+                </dhcp>
+              </ip>
+            </network>
 ...


### PR DESCRIPTION
Cleaned up libvirt network tasks by replacing shell scripts with the virt_net module and unified the network definition logic.