### PR TITLE
Remove bridged networking setup from virtualization role

### DIFF
--- a/group_vars/all/virtualization.yml
+++ b/group_vars/all/virtualization.yml
@@ -26,6 +26,5 @@ virtualization_kvm_qemu:
     - kvm
   networks:
     - default
-    - bridged
     - isolated
 ...

--- a/roles/virtualization/tasks/main.yml
+++ b/roles/virtualization/tasks/main.yml
@@ -61,10 +61,8 @@
         autostart: true
 
     - name: Ensure all libvirt networks are active and set to autostart
-      community.libvirt.virt_net:
-        name: "{{ item }}"
-        state: active
-        autostart: true
+      ansible.builtin.shell: virsh net-autostart "{{ item }}"
+      changed_when: false
       loop: "{{ virtualization_kvm_qemu.networks }}"
 
 ...

--- a/roles/virtualization/tasks/main.yml
+++ b/roles/virtualization/tasks/main.yml
@@ -5,6 +5,7 @@
     - name: Install docker packages
       ansible.builtin.dnf:
         name: "{{ virtualization_docker.packages }}"
+        state: present
 
     - name: Add user to docker group
       ansible.builtin.user:
@@ -38,52 +39,6 @@
         groups: "{{ virtualization_kvm_qemu.user_groups }}"
         append: true
 
-    - name: Get the active physical NIC name
-      ansible.builtin.set_fact:
-        virtualization_active_nic: "{{ ansible_default_ipv4.interface }}"
-
-    - name: Create host Linux bridge br0
-      community.general.nmcli:
-        conn_name: br0
-        ifname: br0
-        type: bridge
-        method4: auto
-        state: present
-      async: 45
-      poll: 5
-
-    - name: Enslave physical NIC to bridge
-      community.general.nmcli:
-        conn_name: "bridge-slave-{{ virtualization_active_nic }}"
-        ifname: "{{ virtualization_active_nic }}"
-        type: ethernet      # The underlying hardware type
-        slave_type: bridge  # The role it plays
-        master: br0         # The controller it belongs to
-        state: present
-      async: 45
-      poll: 5
-
-    - name: Wait for bridge br0 to settle
-      ansible.builtin.pause:
-        seconds: 5
-
-    - name: Define bridged network XML
-      community.libvirt.virt_net:
-        name: bridged
-        state: present
-        xml: |
-          <network>
-            <name>bridged</name>
-            <forward mode="bridge"/>
-            <bridge name="br0"/>
-          </network>
-
-    - name: Ensure bridged network is active and autostarted
-      community.libvirt.virt_net:
-        name: bridged
-        state: active
-        autostart: true
-
     - name: Define isolated network XML
       community.libvirt.virt_net:
         name: isolated
@@ -106,8 +61,10 @@
         autostart: true
 
     - name: Ensure all libvirt networks are active and set to autostart
-      ansible.builtin.shell: virsh net-autostart "{{ item }}"
-      changed_when: false
+      community.libvirt.virt_net:
+        name: "{{ item }}"
+        state: active
+        autostart: true
       loop: "{{ virtualization_kvm_qemu.networks }}"
 
 ...


### PR DESCRIPTION
- Deleted all tasks related to creating and managing Linux bridges (br0) and bridged libvirt networks.
- Simplified virtualization setup to use only default and isolated networks.
- Updated group_vars to remove the obsolete 'bridged' network entry.
- Reduces complexity and avoids common issues with bridged adapters on Fedora/KVM.